### PR TITLE
chore: 닉네임 중복체크 메소드 추가, 회원가입 시 닉네임 입력 추가

### DIFF
--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/UsersInfoController.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/UsersInfoController.java
@@ -44,7 +44,7 @@ public class UsersInfoController {
             throw new RestApiException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
-         usersCommandService.updateUserInfo(updateUserInfo);
+         usersCommandService.updateUserInfo(userSeq, updateUserInfo);
         return ResponseEntity.ok(new SuccessResMessage(SuccessCode.BASIC_UPDATE_SUCCESS));
     }
 

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/CreateUserRequest.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/CreateUserRequest.java
@@ -25,5 +25,7 @@ public class CreateUserRequest {
     @NotBlank(message = "휴대폰 번호는 필수 입력 사항입니다.")
     private String userPhone;
 
+    private String userNickname;  // 선택 입력
+
     private String userSocialYn = "N";  // 기본 회원가입
 }

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/UpdateUserRequest.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/UpdateUserRequest.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class UpdateUserRequest {
 
-    private long userSeq;
     private String userPassword;
 //    @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대폰 번호는 10자리 또는 11자리 숫자여야 합니다.")
     private String userPhone;


### PR DESCRIPTION
🌟개요
---
닉네임 중복체크 메소드 추가, 
회원가입 시 닉네임 입력 추가
🌐연결된 Issues
---

📋작업사항
---

✏️작성한 이슈 외 작업사항
---
수정과 생성에서 닉네임 중복체크 메소드 하나로 합침,
회원가입 시 닉네임 입력 칸 추가, 미입력시에는 그대로 자동생성

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
