### PR TITLE
chore: 게시글, 게시글 댓글 조회 시 응답에 userSeq 추가

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/board/query/dto/PostCommentDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/query/dto/PostCommentDTO.java
@@ -13,6 +13,7 @@ public class PostCommentDTO {
     private Long postSeq;
     private String postTitle;
     private String postCommentContent;
+    private Long postCommentUserSeq;
     private String userNickname;
     private LocalDateTime postCommentCreatedTime;
     private LocalDateTime postCommentUpdatedTime;

--- a/matzipback/src/main/java/com/matzip/matzipback/board/query/dto/PostDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/query/dto/PostDTO.java
@@ -14,6 +14,7 @@ public class PostDTO {
     private String postTitle;                   // 게시글 제목
     private String postContent;                 // 게시글 내용
     private String userNickname;                // 게시글 작성자 닉네임
+    private Long postUserSeq;                       // 게시글 작성자 고유번호
     private LocalDateTime postCreatedTime;      // 게시글 생성 시간
     private LocalDateTime postUpdatedTime;      // 게시글 수정 시간
 

--- a/matzipback/src/main/resources/mappers/boardMappers/PostMapper.xml
+++ b/matzipback/src/main/resources/mappers/boardMappers/PostMapper.xml
@@ -8,6 +8,7 @@
         SELECT
                b.board_category_name
              , a.post_title
+             , a.post_user_seq
              , c.user_nickname
              , a.post_created_time
              , a.post_updated_time
@@ -19,7 +20,7 @@
             AND a.post_title LIKE CONCAT('%', #{postTitle}, '%')
         </if>
         <if test="userNickname != null">
-            AND c.user_nickname LIKE CONCAT('%', #{userNickname})
+            AND c.user_nickname LIKE CONCAT('%', #{userNickname}, '%')
         </if>
         ORDER BY a.post_seq
         LIMIT #{size} OFFSET #{offset}
@@ -36,7 +37,7 @@
             AND a.post_title LIKE CONCAT('%', #{postTitle}, '%')
         </if>
         <if test="userNickname != null">
-            AND c.user_nickname LIKE CONCAT('%', #{userNickname})
+            AND c.user_nickname LIKE CONCAT('%', #{userNickname}, '%')
         </if>
     </select>
 
@@ -44,6 +45,7 @@
         SELECT
                b.board_category_name
              , a.post_title
+             , a.post_user_seq
              , c.user_nickname
              , a.post_created_time
              , a.post_updated_time
@@ -76,6 +78,7 @@
                 b.board_category_name
               , a.post_title
               , a.post_content
+              , a.post_user_seq
               , c.user_nickname
               , a.post_created_time
               , a.post_updated_time
@@ -129,10 +132,11 @@
     <select id="getPostComment" resultType="com.matzip.matzipback.board.query.dto.PostCommentDTO">
         SELECT
                 a.post_comment_seq
+              , a.post_comment_user_seq
               , c.user_nickname
               , a.post_comment_content
-              , a.post_comment_created_time as createdTime
-              , a.post_comment_updated_time as lastUpdateTime
+              , a.post_comment_created_time
+              , a.post_comment_updated_time
           FROM post_comment a
          RIGHT JOIN post b USING (post_seq)
           LEFT JOIN users c ON (a.post_comment_user_seq = c.user_seq)


### PR DESCRIPTION
🌟개요
---
게시글, 게시글 댓글 조회 시 응답에 userSeq 추가

🌐연결된 Issues
---
#50 

📋작업사항
---
게시글이나 게시글 댓글에서 작성자 닉네임을 클릭하면 회원 상세 조회 페이지로 어 갈 수 있도록 user_seq를 응답에 추가

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
