### PR TITLE
fix: #52 리스트 댓글 삭제 본인만 가능하게 컨트롤러 수정

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/controller/ListCmtCommandController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/controller/ListCmtCommandController.java
@@ -49,7 +49,9 @@ public class ListCmtCommandController {
     public ResponseEntity<SuccessResMessage> deleteListCmt(@Valid @RequestBody DeleteListCmtRequset deleteListCmtRequset){
 
         try { if (CustomUserUtils.getCurrentUserAuthorities().iterator().next().getAuthority().equals("user")) {
-
+            if (!CustomUserUtils.getCurrentUserSeq().equals(deleteListCmtRequset.getListCommentUserSeq())) {
+                throw new RestApiException(FORBIDDEN_ACCESS);
+            }
             listCmtCommandService.deleteListCmt(deleteListCmtRequset);
 
             return ResponseEntity


### PR DESCRIPTION
🌟개요
리스트 댓글 삭제 본인만 가능하게 컨트롤러 수정

🌐연결된 Issues
#52 

📋작업사항
컨트롤러에서 본인 인증 로직 추가

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
