### PR TITLE
chore: 회원가입시 닉네임, 휴대폰중복체크 분리 및 시큐리티 허용 url 변경

### DIFF
--- a/matzipuser/src/main/java/com/matzip/matzipuser/responsemessage/SuccessCode.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/responsemessage/SuccessCode.java
@@ -30,7 +30,10 @@ public enum SuccessCode {
     /* 임시 비밀번호 발급 */
     SEND_PASSWORD_EMAIL_SUCCESS(HttpStatus.OK, "비밀번호 재설정 URL이 이메일로 발송되었습니다."),
     /* 회원 로그아웃 성공 */
-    USER_LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃되었습니다. 클라이언트는 토큰을 삭제해야 합니다.");
+    USER_LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃되었습니다. 클라이언트는 토큰을 삭제해야 합니다."),
+
+    /* 중복체크 통과 */
+    AVAILABLE_ELEMENT(HttpStatus.OK, "사용 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/matzipuser/src/main/java/com/matzip/matzipuser/security/config/SecurityConfig.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/security/config/SecurityConfig.java
@@ -48,7 +48,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auths -> {
                     // 회원가입 Post 는 인증 필요 없음
                     auths.requestMatchers(
-                            new AntPathRequestMatcher("/user/api/v1/auth/register"),
 //                            new AntPathRequestMatcher("/user/api/v1/**"),
 //                            new AntPathRequestMatcher("/**"),
                             new AntPathRequestMatcher("/swagger-ui/index.html"),
@@ -113,7 +112,6 @@ public class SecurityConfig {
     private void userAuthConnection(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers(
                 new AntPathRequestMatcher("/user/api/v1/user-activity/point", "PUT"),
-                new AntPathRequestMatcher("/user/api/v1/auth/logout", "POST"),
                 new AntPathRequestMatcher("/user/api/v1/follow", "POST"),
                 new AntPathRequestMatcher("/user/api/v1/user/{userSeq}", "PUT"),
                 new AntPathRequestMatcher("/user/api/v1/user/{userSeq}", "DELETE"),
@@ -130,8 +128,11 @@ public class SecurityConfig {
     // 모든 접근 url
     private void allAuthConnection(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers(
-                new AntPathRequestMatcher("/user/api/v1/auth/mai-verification", "POST"),
+                new AntPathRequestMatcher("/user/api/v1/auth/logout", "POST"),
+                new AntPathRequestMatcher("/user/api/v1/auth/mail-verification", "POST"),
                 new AntPathRequestMatcher("/user/api/v1/auth/chkEmailCode", "POST"),
+                new AntPathRequestMatcher("/user/api/v1/user/check-phone-duplicate", "POST"),
+                new AntPathRequestMatcher("/user/api/v1/user/check-nickname-duplicate", "POST"),
                 new AntPathRequestMatcher("/user/api/v1/auth/register", "POST"),
                 new AntPathRequestMatcher("/user/api/v1/auth/find-email", "POST"),
                 new AntPathRequestMatcher("/user/api/v1/auth/send-pw-reset-url", "POST"),

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/EmailController.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/EmailController.java
@@ -5,6 +5,7 @@ import com.matzip.matzipuser.users.command.application.dto.EmailSendRequest;
 import com.matzip.matzipuser.users.command.application.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -25,7 +26,7 @@ public class EmailController {
 
     @PostMapping("/auth/mail-verification")
     @Operation(summary = "이메일 인증", description = "입력받은 이메일로 인증코드를 발송한다.")
-    public ResponseEntity<String> sendVerificationCode(@RequestBody EmailSendRequest request) {
+    public ResponseEntity<String> sendVerificationCode(@Valid  @RequestBody EmailSendRequest request) {
 //        log.info("POST /api/v1/auth/mail-verification - 이메일 인증요청 : {}", request);
         emailService.sendSignUpEmail(request.getUserEmail(), request.getUserName());
 

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/UsersInfoController.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/UsersInfoController.java
@@ -5,10 +5,8 @@ import com.matzip.matzipuser.exception.ErrorCode;
 import com.matzip.matzipuser.exception.RestApiException;
 import com.matzip.matzipuser.responsemessage.SuccessCode;
 import com.matzip.matzipuser.responsemessage.SuccessResMessage;
+import com.matzip.matzipuser.users.command.application.dto.*;
 import com.matzip.matzipuser.users.command.application.service.UsersCommandService;
-import com.matzip.matzipuser.users.command.application.dto.DeleteUserRequest;
-import com.matzip.matzipuser.users.command.application.dto.UpdateUserRequest;
-import com.matzip.matzipuser.users.command.application.dto.UpdateUserStatusDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -77,6 +75,23 @@ public class UsersInfoController {
         usersCommandService.updateUserStatus(userSeq, updateUserStatusDTO);
 
         return ResponseEntity.ok().build();
+    }
+
+    /* 휴대폰 중복체크 */
+    @PostMapping("/check-phone-duplicate")
+    @Operation(summary = "휴대폰 번호 중복 체크", description = "회원가입과 정보수정 시 입력한 휴대폰 번호의 중복 여부를 확인한다.")
+    public ResponseEntity<SuccessResMessage> checkPhoneDuplicate(@Valid @RequestBody PhoneCheckRequest request) {
+        usersCommandService.isPhoneDuplicated(request.getUserPhone());
+
+        return ResponseEntity.ok(new SuccessResMessage(SuccessCode.AVAILABLE_ELEMENT));
+    }
+
+    /* 닉네임 중복체크 */
+    @PostMapping("/check-nickname-duplicate")
+    @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복 여부를 확인한다.")
+    public ResponseEntity<SuccessResMessage> checkNicknameDuplicate(@Valid @RequestBody NicknameCheckRequest request) {
+        usersCommandService.isNicknameDuplicated(request.getUserNickname());
+        return ResponseEntity.ok(new SuccessResMessage(SuccessCode.AVAILABLE_ELEMENT));
     }
 
 

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/CreateUserRequest.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/CreateUserRequest.java
@@ -26,7 +26,6 @@ public class CreateUserRequest {
     @NotBlank(message = "휴대폰 번호는 필수 입력 사항입니다.")
     @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대폰 번호는 10자리 또는 11자리 숫자여야 합니다.")
     private String userPhone;
-    @Size(min = 2, max = 16, message = "닉네임은 2자 이상, 16자 이하로 입력해주세요.")
     private String userNickname;  // 선택 입력
 
     private String userSocialYn = "N";  // 기본 회원가입

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/EmailSendRequest.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/EmailSendRequest.java
@@ -1,11 +1,16 @@
 package com.matzip.matzipuser.users.command.application.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class EmailSendRequest {
+    @NotBlank(message = "이메일은 필수 입력사항입니다.")
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
     private String userEmail;
+    @NotBlank(message = "이름은 필수 입력 사항입니다.")
     private String userName;
 }

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/NicknameCheckRequest.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/NicknameCheckRequest.java
@@ -1,0 +1,14 @@
+package com.matzip.matzipuser.users.command.application.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NicknameCheckRequest {
+    @Size(min = 2, max = 16, message = "닉네임은 2자 이상, 16자 이하로 입력해주세요.")
+    public String userNickname;
+}

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/PhoneCheckRequest.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/PhoneCheckRequest.java
@@ -1,0 +1,16 @@
+package com.matzip.matzipuser.users.command.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PhoneCheckRequest {
+    @NotBlank(message = "휴대폰 번호는 필수 입력 사항입니다.")
+    @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대폰 번호는 10자리 또는 11자리 숫자여야 합니다.")
+    public String userPhone;
+}

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/service/EmailService.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/service/EmailService.java
@@ -2,6 +2,7 @@ package com.matzip.matzipuser.users.command.application.service;
 
 import com.matzip.matzipuser.exception.ErrorCode;
 import com.matzip.matzipuser.exception.RestApiException;
+import com.matzip.matzipuser.users.command.domain.service.UsersDomainService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import static com.matzip.matzipuser.exception.ErrorCode.SEND_MAIL_FAIL;
 public class EmailService {
 
     private final JavaMailSender mailSender;
+    private final UsersDomainService usersDomainService;
     private final Map<String, String> verificationCodes = new HashMap<>();  // 인증 코드 저장
     private final Map<String, LocalDateTime> codeExpireTimes = new HashMap<>(); // 인증 코드 만료 시간 저장
     private final Map<String, Boolean> emailVerifiedMap = new HashMap<>(); // 인증 성공 상태 저장
@@ -38,6 +40,11 @@ public class EmailService {
     // 회원가입 인증코드 보내기
     public void sendSignUpEmail(String email, String name){
 //        log.info("========인증코드 발송 서비스 - sendSignUpEmail : email: {}========", email);
+
+        if(usersDomainService.existsByUserEmail(email)){
+            throw new RestApiException(ErrorCode.DUPLICATED_USER_EMAIL);
+        }
+
         String subject = "[맛zip]회원가입 인증코드입니다.";
         String verificationCode = makeVerificationCode();
         verificationCodes.put(email, verificationCode);

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/service/UsersCommandService.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/service/UsersCommandService.java
@@ -20,7 +20,6 @@ import static com.matzip.matzipuser.exception.ErrorCode.*;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
 public class UsersCommandService {
 
     private final UsersDomainService usersDomainService;
@@ -34,28 +33,33 @@ public class UsersCommandService {
     @Transactional
     public void createUser(CreateUserRequest newUser) {
 
-        // 이메일 중복체크
-        if(usersDomainService.existsByUserEmail(newUser.getUserEmail()))
-            throw new RestApiException(ErrorCode.DUPLICATED_USER_EMAIL);
-
         // 이메일 인증 여부 확인
         if (!emailService.isEmailVerified(newUser.getUserEmail()))
+            throw new RestApiException(ErrorCode.NOT_AUTHORIZED_USER_EMAIL);
+
+        // 이메일 중복체크(인증이 완료된 경우 건너뜀)
+        if (usersDomainService.existsByUserEmail(newUser.getUserEmail())) {
             throw new RestApiException(ErrorCode.DUPLICATED_USER_EMAIL);
+        }
 
         // 휴대폰 증복 체크
-        usersDomainService.isPhoneDuplicated(newUser.getUserPhone());
+        isPhoneDuplicated(newUser.getUserPhone());
 
 
         // 닉네임 중복 체크 (사용자가 입력한 경우)
-        if (newUser.getUserNickname() != null && !newUser.getUserNickname().trim().isEmpty()) {
-            usersDomainService.checkNicknameDuplication(newUser.getUserNickname());
+        if (newUser.getUserNickname() != null && !newUser.getUserNickname().isBlank()) {
+            isNicknameDuplicated(newUser.getUserNickname());
         }
 
         // CreateUserRequest DTO를 Users 엔티티로 변환
         Users users = modelMapper.map(newUser, Users.class);
 
         // 비밀번호 암호화 후 Users 객체에 설정
-        users.encryptPassword(passwordEncoder.encode(newUser.getUserPassword()));
+//        log.info("회원가입 요청 수신: {}", newUser);
+//        log.info("암호화 전 비밀번호: {}", newUser.getUserPassword());
+        String encryptedPassword = passwordEncoder.encode(newUser.getUserPassword());
+//        log.info("암호화된 비밀번호: {}", encryptedPassword);
+        newUser.setUserPassword(encryptedPassword);
 
         // 닉네임이 없는 경우 자동 생성
         if (newUser.getUserNickname() == null || newUser.getUserNickname().isBlank()) {
@@ -149,6 +153,7 @@ public class UsersCommandService {
     }
 
     // 비밀번호 재설정 토큰
+    @Transactional
     public void sendPasswordResetUrl(FindPasswordRequest findPasswordRequest) {
 
         UserPwTokenDTO userPwTokenDTO = usersDomainService.findByUserEmailAndUserPhone(findPasswordRequest.getUserEmail(), findPasswordRequest.getUserPhone());
@@ -169,11 +174,31 @@ public class UsersCommandService {
     }
 
     // 토큰을 이용한 비밀번호 재설정
+    @Transactional
     public void resetPassword(String token, ResetPasswordRequest request) {
 
         UserPwDTO userPwDTO = usersDomainService.findByPwResetToken(token);
         // 새로운 비밀번호 설정
         usersDomainService.saveNewPw(userPwDTO, request);
         usersDomainService.makeTokenDueTimeNull(userPwDTO);
+    }
+
+    // 휴대폰 중복체크
+    @Transactional
+    public void isPhoneDuplicated(String userPhone) {
+        usersDomainService.isPhoneDuplicated(userPhone);
+    }
+
+    // 닉네임 중복체크
+    @Transactional
+    public void isNicknameDuplicated(String userNickname) {
+        usersDomainService.checkNicknameDuplication(userNickname);
+    }
+
+    // 이메일 중복체크
+    @Transactional
+    public void isEmailDuplicated(String email) {
+        if(usersDomainService.existsByUserEmail(email))
+            throw new RestApiException(ErrorCode.DUPLICATED_USER_EMAIL);
     }
 }


### PR DESCRIPTION
🌟개요
---
회원가입시 닉네임, 휴대폰중복체크 분리 및 시큐리티 허용 url 변경

🌐연결된 Issues
---

📋작업사항
---
회원가입시 닉네임, 휴대폰중복체크 분리(dto, 메소드 생성)
시큐리티 허용 url 추가, 변경 및 오타 수정
이메일중복체크와 인증확인 순서 변경
회원가입시 모델매퍼와 객체가 혼용으로 쓰이던것 수정

✏️작성한 이슈 외 작업사항
---
성공코드 추가

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?
